### PR TITLE
Rename (dis)allow options to `only` and `ignore`

### DIFF
--- a/packages/franc-cli/index.js
+++ b/packages/franc-cli/index.js
@@ -17,9 +17,17 @@ var cli = meow(help(), {
       type: 'string',
       alias: 'w'
     },
+    only: {
+      type: 'string',
+      alias: 'o'
+    },
     blacklist: {
       type: 'string',
       alias: 'b'
+    },
+    ignore: {
+      type: 'string',
+      alias: 'i'
     },
     minLength: {
       type: 'string',
@@ -41,13 +49,10 @@ var flags = cli.flags
 
 flags.minLength = Number(flags.minLength) || null
 
-if (flags.whitelist) {
-  flags.whitelist = String(flags.whitelist).split(',')
-}
-
-if (flags.blacklist) {
-  flags.blacklist = String(flags.blacklist).split(',')
-}
+flags.whitelist = list(flags.whitelist)
+flags.blacklist = list(flags.blacklist)
+flags.only = flags.whitelist.concat(list(flags.only))
+flags.ignore = flags.blacklist.concat(list(flags.ignore))
 
 if (value) {
   detect(value)
@@ -62,8 +67,8 @@ if (value) {
 function detect(value) {
   var options = {
     minLength: flags.minLength,
-    whitelist: flags.whitelist,
-    blacklist: flags.blacklist
+    only: flags.only,
+    ignore: flags.ignore
   }
 
   if (flags.all) {
@@ -84,8 +89,8 @@ function help() {
     '  -h, --help                    output usage information',
     '  -v, --version                 output version number',
     '  -m, --min-length <number>     minimum length to accept',
-    '  -w, --whitelist <string>      allow languages',
-    '  -b, --blacklist <string>      disallow languages',
+    '  -o, --only <string>           allow languages',
+    '  -i, --ignore <string>         disallow languages',
     '  -a, --all                     display all guesses',
     '',
     'Usage:',
@@ -98,20 +103,16 @@ function help() {
     '$ echo "এটি একটি ভাষা একক IBM স্ক্রিপ্ট" | ' + command,
     '# ' + franc('এটি একটি ভাষা একক IBM স্ক্রিপ্ট'),
     '',
-    '# blacklist certain languages',
-    '$ ' + command + ' --blacklist por,glg "O Brasil caiu 26 posições"',
-    '# ' +
-      franc('O Brasil caiu 26 posições', {
-        blacklist: ['por', 'glg']
-      }),
+    '# ignore certain languages',
+    '$ ' + command + ' --ignore por,glg "O Brasil caiu 26 posições"',
+    '# ' + franc('O Brasil caiu 26 posições', {ignore: ['por', 'glg']}),
     '',
-    '# output language from stdin with whitelist',
-    '$ echo "Alle mennesker er født frie og" | ' +
-      command +
-      ' --whitelist nob,dan',
-    '# ' +
-      franc('Alle mennesker er født frie og', {
-        whitelist: ['nob', 'dan']
-      })
+    '# output language from stdin with only',
+    '$ echo "Alle mennesker er født frie og" | ' + command + ' --only nob,dan',
+    '# ' + franc('Alle mennesker er født frie og', {only: ['nob', 'dan']})
   ].join('\n')
+}
+
+function list(value) {
+  return value ? String(value).split(',') : []
 }

--- a/readme.md
+++ b/readme.md
@@ -69,10 +69,10 @@ Yields:
   ... 116 more items ]
 ```
 
-###### `whitelist`
+###### `only`
 
 ```js
-console.log(franc.all('O Brasil caiu 26 posições', {whitelist: ['por', 'spa']}))
+console.log(franc.all('O Brasil caiu 26 posições', {only: ['por', 'spa']}))
 ```
 
 Yields:
@@ -81,10 +81,10 @@ Yields:
 [ [ 'por', 1 ], [ 'spa', 0.799906059182715 ] ]
 ```
 
-###### `blacklist`
+###### `ignore`
 
 ```js
-console.log(franc.all('O Brasil caiu 26 posições', {blacklist: ['src', 'glg']}))
+console.log(franc.all('O Brasil caiu 26 posições', {ignore: ['src', 'glg']}))
 ```
 
 Yields:
@@ -118,8 +118,8 @@ Options:
   -h, --help                    output usage information
   -v, --version                 output version number
   -m, --min-length <number>     minimum length to accept
-  -w, --whitelist <string>      allow languages
-  -b, --blacklist <string>      disallow languages
+  -o, --only <string>           allow languages
+  -i, --ignore <string>         disallow languages
   -a, --all                     display all guesses
 
 Usage:
@@ -132,12 +132,12 @@ $ franc "Alle menslike wesens word vry"
 $ echo "এটি একটি ভাষা একক IBM স্ক্রিপ্ট" | franc
 # ben
 
-# blacklist certain languages
-$ franc --blacklist por,glg "O Brasil caiu 26 posições"
+# ignore certain languages
+$ franc --ignore por,glg "O Brasil caiu 26 posições"
 # src
 
-# output language from stdin with whitelist
-$ echo "Alle mennesker er født frie og" | franc --whitelist nob,dan
+# output language from stdin with only
+$ echo "Alle mennesker er født frie og" | franc --only nob,dan
 # nob
 ```
 

--- a/script/build.js
+++ b/script/build.js
@@ -29,7 +29,7 @@ var mono = require(path.join(__dirname, '..', 'package.json'))
 /* Persian (fas, macrolanguage) contains Western Persian (pes)
  * and Dari (prs).  They’re so similar in UDHR that using both
  * will result in incorrect results, so add the macrolanguage
- * instead. (note: prs and pes are blacklisted) */
+ * instead. (note: prs and pes are ignored) */
 speakers = xtend(speakers, {
   fas: speakers.prs + speakers.pes
 })

--- a/script/udhr-exclude.js
+++ b/script/udhr-exclude.js
@@ -1,4 +1,4 @@
-/* Some languages are blacklisted, no matter what
+/* Some languages are ignored, no matter what
  * `threshold` is chosen. */
 module.exports = [
   /* Using both results in incorrect results.

--- a/test/api.js
+++ b/test/api.js
@@ -49,27 +49,27 @@ test('franc()', function(t) {
   )
 
   t.notEqual(
-    franc(fixtureB, {blacklist: [franc(fixtureB)]}),
+    franc(fixtureB, {ignore: [franc(fixtureB)]}),
     franc(fixtureB),
-    'should accept `blacklist`'
+    'should accept `ignore`'
   )
 
   t.deepEqual(
-    franc(fixtures.aii.fixture, {blacklist: ['aii']}),
+    franc(fixtures.aii.fixture, {ignore: ['aii']}),
     'und',
-    'should support `blacklist` if the script can only be in that language'
+    'should support `ignore` if the script can only be in that language'
   )
 
   t.equal(
-    franc(fixtureB, {whitelist: [languageA]}),
+    franc(fixtureB, {only: [languageA]}),
     languageA,
-    'should accept `whitelist`'
+    'should accept `only`'
   )
 
   t.equal(
-    franc(hebrew, {whitelist: ['eng']}),
+    franc(hebrew, {only: ['eng']}),
     'und',
-    'should accept `whitelist` for different scripts'
+    'should accept `only` for different scripts'
   )
 
   t.equal(franc('the', {minLength: 3}), 'sco', 'should accept `minLength` (1)')
@@ -131,25 +131,25 @@ test('franc.all()', function(t) {
 
   t.deepEqual(
     franc
-      .all(fixtureB, {blacklist: [franc(fixtureB)]})
+      .all(fixtureB, {ignore: [franc(fixtureB)]})
       .map(function(tuple) {
         return tuple[0]
       })
       .indexOf(franc(fixtureB)),
     -1,
-    'should accept `blacklist`'
+    'should accept `ignore`'
   )
 
   t.deepEqual(
-    franc.all(fixtureB, {whitelist: [languageA]}),
+    franc.all(fixtureB, {only: [languageA]}),
     [[languageA, 1]],
-    'should accept `whitelist`'
+    'should accept `only`'
   )
 
   t.deepEqual(
-    franc.all(hebrew, {whitelist: ['eng']}),
+    franc.all(hebrew, {only: ['eng']}),
     [['und', 1]],
-    'should accept `whitelist` for different scripts'
+    'should accept `only` for different scripts'
   )
 
   t.deepEqual(

--- a/test/cli.js
+++ b/test/cli.js
@@ -10,13 +10,22 @@ var pkg = require(path.resolve(root, 'package.json'))
 var cli = path.resolve(root, 'index.js')
 
 test('cli', function(t) {
-  t.plan(17)
-  ;['-v', '--version'].forEach(function(flag) {
+  var help = ['-h', '--help']
+  var version = ['-v', '--version']
+  var disallow = ['-i', '--ignore', '-b', '--blacklist']
+  var allow = ['-o', '--only', '-w', '--whitelist']
+  var minLength = ['-m', '--min-length']
+  var all = ['-a', '--all']
+
+  t.plan(21)
+
+  version.forEach(function(flag) {
     execa.stdout(cli, [flag]).then(function(result) {
       t.equal(result, pkg.version, flag)
     }, t.ifErr)
   })
-  ;['-h', '--help'].forEach(function(flag) {
+
+  help.forEach(function(flag) {
     execa.stdout(cli, [flag]).then(function(result) {
       t.ok(/^\s+CLI to detect the language of text/.test(result), flag)
     }, t.ifErr)
@@ -57,21 +66,24 @@ test('cli', function(t) {
       st.equal(result, 'afr', 'stdin')
     }, st.ifErr)
   })
-  ;['-w', '--whitelist'].forEach(function(flag) {
+
+  allow.forEach(function(flag) {
     execa
       .stdout(cli, [flag, 'nob,dan', 'Alle mennesker er født frie og'])
       .then(function(result) {
         t.equal(result, 'nob', flag)
       }, t.ifErr)
   })
-  ;['-b', '--blacklist'].forEach(function(flag) {
+
+  disallow.forEach(function(flag) {
     execa
       .stdout(cli, [flag, 'por,glg', 'O Brasil caiu 26 posições'])
       .then(function(result) {
         t.equal(result, 'src', flag)
       }, t.ifErr)
   })
-  ;['-m', '--min-length'].forEach(function(flag) {
+
+  minLength.forEach(function(flag) {
     execa.stdout(cli, [flag, '3', 'the']).then(function(result) {
       t.equal(result, 'sco', flag + ' (satisfied)')
     }, t.ifErr)
@@ -80,7 +92,8 @@ test('cli', function(t) {
       t.equal(result, 'und', flag + ' (unsatisfied)')
     }, t.ifErr)
   })
-  ;['-a', '--all'].forEach(function(flag) {
+
+  all.forEach(function(flag) {
     execa
       .stdout(cli, [flag, 'Alle menslike wesens word vry'])
       .then(function(result) {


### PR DESCRIPTION
These terms are better than `blacklist` and `whitelist` as they are
more descriptive.

This change is backwards compatible.