### PR TITLE
Fixed Chinese misdetections of Japanese input

### DIFF
--- a/script/build.js
+++ b/script/build.js
@@ -124,7 +124,8 @@ function generate(basename) {
     })
   })
 
-  /* Push Japanese. */
+  /* Push Japanese.
+   * Unicode Kanji Table from http://www.rikai.com/library/kanjitables/kanji_codes.unicode.shtml */
   var kanjiRegexSource = '[\u3400-\u4DB5\u4E00-\u9FAF]'
   regularExpressions.jpn = new RegExp(
     expressions.Hiragana.source + '|' + expressions.Katakana.source + '|' + kanjiRegexSource,

--- a/script/build.js
+++ b/script/build.js
@@ -125,8 +125,9 @@ function generate(basename) {
   })
 
   /* Push Japanese. */
+  var kanjiRegexSource = '[\u3400-\u4DB5\u4E00-\u9FAF]'
   regularExpressions.jpn = new RegExp(
-    expressions.Hiragana.source + '|' + expressions.Katakana.source,
+    expressions.Hiragana.source + '|' + expressions.Katakana.source + '|' + kanjiRegexSource,
     'g'
   )
 

--- a/test/api.js
+++ b/test/api.js
@@ -48,6 +48,36 @@ test('franc()', function(t) {
     'should work on unique-scripts with many latin characters (2)'
   )
 
+  t.equal(
+    franc('すべての人は、生命、自由及び身体の安全に対する権利を有する。'),
+    'jpn',
+    'should detect Japanese even when Han ratio > 0.5 (udhr_jpn art 3) (1)'
+  )
+
+  t.equal(
+    franc(
+      [
+        'すべての人は、憲法又は法律によって与えられた基本的権利を侵害する行為に対し、',
+        '権限を有する国内裁判所による効果的な救済を受ける権利を有する。'
+      ].join('')
+    ),
+    'jpn',
+    'should detect Japanese even when Han ratio > 0.5 (udhr_jpn art 8) (2)'
+  )
+
+  t.equal(
+    franc(
+      [
+        '成年の男女は、人種、国籍又は宗教によるいかなる制限をも受けることなく、婚姻し、',
+        'かつ家庭をつくる権利を有する。成年の男女は、婚姻中及びその解消に際し、',
+        '婚姻に関し平等の権利を有する。婚姻は、婚姻の意思を有する両当事者の自由かつ完全な合意によってのみ成立する。',
+        '家庭は、社会の自然かつ基礎的な集団単位であって、社会及び国の保護を受ける権利を有する。'
+      ].join('')
+    ),
+    'jpn',
+    'should detect Japanese even when Han ratio > 0.5 (udhr_jpn art 16) (3)'
+  )
+
   t.notEqual(
     franc(fixtureB, {ignore: [franc(fixtureB)]}),
     franc(fixtureB),


### PR DESCRIPTION
Since Japanese regex included only Hiragana and Katakana, every input containing kana but more than 50% of Han characters was mistakenly detected as Chinese.

This fix is necessary because many Japanese texts (especially technical ones) may have a kanji ratio higher than 50%. Since the detect method counts the occurrences of matching expressions (characters, in this case), for Japanese it would match only kana (< 50% of total characters), hence returning Chinese as the top language. But if there is even just one kana, the text should be detected as Japanese.

A trivial example:

持込申請最悪状態完了

contains Han characters only so I would agree with it being detected as Chinese, but if I insert the hiragana は particle as follows:

持込申請**は**最悪状態完了

it should be detected as Japanese, because it is a mostly correct Japanese sentence (abbreviated, if anything), but instead franc reports it as Chinese, due to the fact that 90% of the characters are Han and only 10% is kana.

In order to prevent that, I have added the regex for Japanese kanji, which in my opinion is cleaner than just throwing in the whole Han block, so that when detecting also kanji would be matched for Japanese. So, in the examples above, the first case would still be (correctly) detected as Chinese, but the second one would have a 90% score for Chinese and a 100% score for Japanese, hence being correctly detected as Japanese.